### PR TITLE
fix(GrafanaExport): fix load data to db

### DIFF
--- a/outboxml/export_results.py
+++ b/outboxml/export_results.py
@@ -437,7 +437,7 @@ class GrafanaExport:
     def __init__(self,
                  df: pd.DataFrame,
                  table_name: str = 'FrameworkTest',
-                 schema: str = '',
+                 schema: str = 'public',
                  connection=None):
         self.df = df
         if self.df.empty:


### PR DESCRIPTION
Исправлена ошибка `grafana export error||(psycopg2.errors.DuplicateTable) relation "EnergyEfficiency" already exists` Которая возникала на этапе загрузки результатов в базу данных